### PR TITLE
Improve setup workflow and script integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,81 @@ Das Setup-System erkennt automatisch:
 ./scripts/setup.sh --recover           # Setup nach Fehlern fortsetzen
 ```
 
+## 🛠 Installation über das interaktive Menü
+
+Agent-NN bietet ein interaktives Setup-Menü, mit dem du das System vollständig oder modular einrichten kannst – inklusive Abhängigkeitsprüfung, automatischer Paketinstallation und optionaler `sudo`-Verwendung.
+
+### 🔃 Schnellstart (empfohlen)
+
+```bash
+git clone https://github.com/EcoSphereNetwork/Agent-NN.git
+cd Agent-NN
+./scripts/setup.sh
+```
+
+### 📋 Menü-Optionen
+
+| Option | Beschreibung |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `1`    | 🧠 Komplettes Setup (empfohlen) – installiert alle System- und Python-Abhängigkeiten, richtet Umgebungen ein, startet Docker und baut das Frontend |
+| `2`    | 🐍 Nur Python-Abhängigkeiten installieren (Poetry, venv, Pakete) |
+| `3`    | 🧱 Nur System-Abhängigkeiten installieren (Node.js, npm, curl, poetry, docker, etc.) |
+| `4`    | 🎨 Frontend bauen (nur UI) |
+| `5`    | 🐳 Docker-Container starten (nur Backend-Services) |
+| `6`    | ⚙️ MCP-Server starten (Model Context Protocol) |
+| `7`    | 📊 Installationsstatus & Versionen anzeigen |
+| `8`    | ❌ Abbrechen und Setup beenden |
+
+### ⚙️ Erweiterte Optionen
+
+Du kannst das Setup auch **automatisiert** über CLI ausführen:
+
+```bash
+# Mit automatischer Paketinstallation & sudo
+./scripts/setup.sh --with-sudo --auto-install
+```
+
+**Verfügbare Flags:**
+
+| Flag             | Wirkung                                                                 |           |                                                                                                  |
+| ---------------- | ----------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------ |
+| `--with-sudo`    | Verwendet `sudo`, um Systempakete automatisch zu installieren           |           |                                                                                                  |
+| `--auto-install` | Installiert fehlende Abhängigkeiten automatisch (systemweit oder lokal) |           |                                                                                                  |
+| \`--preset=dev   | ci                                                                      | minimal\` | Verwendet vordefinierte Setup-Presets (für schnelle CI-Integration oder reduzierte Installation) |
+
+### 🧪 Voraussetzungen
+
+Falls du das Setup manuell ausführen möchtest, achte auf folgende Tools:
+
+* Python ≥ 3.10
+* [Poetry](https://python-poetry.org/docs/#installation)
+* Node.js & npm
+* Docker & Docker Compose
+* curl, git
+
+Fehlende Komponenten werden im Setup-Menü erkannt und (je nach Option) automatisch installiert.
+
+### 📁 Log-Dateien & Status
+
+Alle Setup-Aktivitäten werden geloggt:
+
+* **Setup-Log:** `logs/setup.log`
+* **Installationsstatus:** `.agentnn/status.json`
+
+Damit kannst du Installationen nachvollziehen oder fortsetzen.
+
+### 🧯 Hilfe & Wiederherstellung
+
+Falls die Installation fehlschlägt oder du etwas zurücksetzen möchtest:
+
+```bash
+# Nur Setup neu starten (bestehende Dateien bleiben erhalten)
+./scripts/setup.sh
+
+# Reparatur-Skripte anzeigen
+ls ./scripts/repair/
+```
+
 #### Presets
 
 Wiederkehrende Einstellungen lassen sich über `--preset` laden:

--- a/scripts/lib/menu_utils.sh
+++ b/scripts/lib/menu_utils.sh
@@ -8,25 +8,36 @@ __menu_utils_init
 
 interactive_menu() {
     local options=(
-        "Komplettes Setup (Empfohlen)" "Nur Python-Abhängigkeiten installieren" \
-        "Nur Frontend bauen" "Docker-Container starten" "Projekt testen" "Abbrechen"
+        "Komplettes Setup" \
+        "Nur Python-Abhängigkeiten" \
+        "Nur System-Abhängigkeiten" \
+        "Frontend bauen" \
+        "Docker starten" \
+        "MCP starten" \
+        "Status anzeigen" \
+        "Abbrechen"
     )
+    local count=${#options[@]}
     if command -v whiptail >/dev/null; then
         local choice
-        choice=$(whiptail --title "Agent-NN Setup" --menu "Aktion wählen:" 20 78 6 \
+        choice=$(whiptail --title "Agent-NN Setup" --menu "Aktion wählen:" 20 78 8 \
             1 "${options[0]}" \
             2 "${options[1]}" \
             3 "${options[2]}" \
             4 "${options[3]}" \
             5 "${options[4]}" \
-            6 "${options[5]}" 3>&1 1>&2 2>&3) || exit 1
+            6 "${options[5]}" \
+            7 "${options[6]}" \
+            8 "${options[7]}" 3>&1 1>&2 2>&3) || exit 1
         case $choice in
             1) RUN_MODE="full" ;;
             2) RUN_MODE="python" ;;
-            3) RUN_MODE="frontend" ;;
-            4) RUN_MODE="docker" ;;
-            5) RUN_MODE="test" ;;
-            6) exit 0 ;;
+            3) RUN_MODE="system" ;;
+            4) RUN_MODE="frontend" ;;
+            5) RUN_MODE="docker" ;;
+            6) RUN_MODE="mcp" ;;
+            7) RUN_MODE="status" ;;
+            8) exit 0 ;;
         esac
     else
         PS3="Auswahl: "
@@ -34,10 +45,12 @@ interactive_menu() {
             case $REPLY in
                 1) RUN_MODE="full"; break ;;
                 2) RUN_MODE="python"; break ;;
-                3) RUN_MODE="frontend"; break ;;
-                4) RUN_MODE="docker"; break ;;
-                5) RUN_MODE="test"; break ;;
-                6) exit 0 ;;
+                3) RUN_MODE="system"; break ;;
+                4) RUN_MODE="frontend"; break ;;
+                5) RUN_MODE="docker"; break ;;
+                6) RUN_MODE="mcp"; break ;;
+                7) RUN_MODE="status"; break ;;
+                8) exit 0 ;;
                 *) echo "Ungültige Auswahl";;
             esac
         done

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -423,6 +423,15 @@ main() {
                 start_docker_services "docker-compose.yml" || exit 1
             fi
             ;;
+        system)
+            "$SCRIPT_DIR/install_dependencies.sh" ${SUDO_CMD:+--with-sudo} --auto-install || exit 1
+            ;;
+        mcp)
+            "$SCRIPT_DIR/start_mcp.sh" || exit 1
+            ;;
+        status)
+            "$SCRIPT_DIR/status.sh" || exit 0
+            ;;
         test)
             run_project_tests || exit 1
             ;;

--- a/tests/test_scripts_integrity.sh
+++ b/tests/test_scripts_integrity.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+errors=0
+while IFS= read -r file; do
+    case "$file" in
+        *.sh)
+            bash -n "$file" || { echo "Syntaxfehler in $file" >&2; errors=$((errors+1)); }
+            ;;
+        *.py)
+            python -m py_compile "$file" 2>/dev/null || { echo "Syntaxfehler in $file" >&2; errors=$((errors+1)); }
+            ;;
+    esac
+done < <(git ls-files 'scripts/**/*.sh' 'scripts/**/*.py')
+
+if [[ $errors -gt 0 ]]; then
+    echo "$errors Fehler gefunden"
+    exit 1
+else
+    echo "Alle Skripte OK"
+fi


### PR DESCRIPTION
## Summary
- extend README with interactive menu instructions
- expand menu options in `menu_utils.sh`
- add system, MCP and status modes to `setup.sh`
- enhance installer utilities with `require_or_install*`
- add simple script integrity check for CI

## Testing
- `./tests/ci_check.sh` *(fails: would reformat tests/cli/test_submit.py)*
- `./tests/test_scripts_integrity.sh`


------
https://chatgpt.com/codex/tasks/task_e_687611a2924883249576fd933d727da4