### PR TITLE
Refactor setup scripts with richer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ cd Agent-NN
 
 | Option | Beschreibung |
 | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `1`    | 🧠 Komplettes Setup (empfohlen) – installiert alle System- und Python-Abhängigkeiten, richtet Umgebungen ein, startet Docker und baut das Frontend |
-| `2`    | 🐍 Nur Python-Abhängigkeiten installieren (Poetry, venv, Pakete) |
-| `3`    | 🧱 Nur System-Abhängigkeiten installieren (Node.js, npm, curl, poetry, docker, etc.) |
-| `4`    | 🎨 Frontend bauen (nur UI) |
-| `5`    | 🐳 Docker-Container starten (nur Backend-Services) |
-| `6`    | ⚙️ MCP-Server starten (Model Context Protocol) |
-| `7`    | 📊 Installationsstatus & Versionen anzeigen |
-| `8`    | ❌ Abbrechen und Setup beenden |
+| `1`    | 💡 Schnellstart – alles automatisch installieren |
+| `2`    | 🧱 Systemabhängigkeiten (curl, git, Node.js, Docker) |
+| `3`    | 🐍 Python & Poetry einrichten |
+| `4`    | 🎨 Frontend bauen |
+| `5`    | 🐳 Docker-Komponenten starten |
+| `6`    | 🧪 Tests & CI ausführen |
+| `7`    | 🔁 Alles neu installieren / Reparieren |
+| `8`    | ❌ Abbrechen |
 
 ### ⚙️ Erweiterte Optionen
 
@@ -110,12 +110,15 @@ Du kannst das Setup auch **automatisiert** über CLI ausführen:
 
 **Verfügbare Flags:**
 
-| Flag             | Wirkung                                                                 |           |                                                                                                  |
-| ---------------- | ----------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------ |
-| `--with-sudo`    | Verwendet `sudo`, um Systempakete automatisch zu installieren           |           |                                                                                                  |
-| `--auto-install` | Installiert fehlende Abhängigkeiten automatisch (systemweit oder lokal) |           |                                                                                                  |
-| \`--preset=dev   | ci                                                                      | minimal\` | Verwendet vordefinierte Setup-Presets (für schnelle CI-Integration oder reduzierte Installation) |
 
+| Flag | Beschreibung |
+| ---- | ------------ |
+| `--full` | Komplettes Setup ohne Rückfragen |
+| `--auto-install` | Fehlende Pakete automatisch installieren |
+| `--with-sudo` | Paketinstallation mit sudo ausführen |
+| `--no-docker` | Docker-Schritte überspringen |
+| `--preset=dev|minimal|ci` | Vordefinierte Setup-Presets |
+| `--recover` | Bereits erledigte Schritte überspringen |
 ### 🧪 Voraussetzungen
 
 Falls du das Setup manuell ausführen möchtest, achte auf folgende Tools:

--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -6,17 +6,19 @@ source "$SCRIPT_DIR/lib/log_utils.sh"
 cat <<'EOT'
 Agent-NN Befehlsübersicht
 
-  ./scripts/setup.sh         Vollständiges oder teilweises Setup
-  ./scripts/install.sh       Abhängigkeiten gezielt installieren
+  ./scripts/setup.sh         Interaktives Setup-Menü
+  ./scripts/install.sh       Einzelne Komponenten installieren
   ./scripts/start_docker.sh  Docker-Services starten
   ./scripts/build_frontend.sh Frontend bauen
   ./scripts/build_and_test.sh Docker-Image bauen und Tests ausführen
 
 Wichtige Flags für setup.sh:
-  --full        Komplettes Setup ohne Rückfragen
-  --minimal     Nur Python-Abhängigkeiten installieren
-  --no-docker   Docker-Schritte überspringen
-  --with-docker Setup bricht ab, wenn Docker fehlt
+  --full           Komplettes Setup ohne Rückfragen
+  --auto-install   Fehlende Pakete automatisch installieren
+  --with-sudo      Systemweite Installation mit sudo
+  --no-docker      Docker-Schritte überspringen
+  --preset=dev|minimal|ci  Vordefinierte Setups
+  --recover        Fehlgeschlagene Schritte überspringen
 
 Empfohlene Reihenfolge:
   1. ./scripts/setup.sh --full

--- a/scripts/helpers/env.sh
+++ b/scripts/helpers/env.sh
@@ -64,6 +64,8 @@ check_system_dependencies() {
     local missing_deps=()
     local deps=(
         "python3:Python 3"
+        "pip:pip"
+        "curl:curl"
         "node:Node.js"
         "npm:npm"
         "git:Git"
@@ -81,8 +83,8 @@ check_system_dependencies() {
     if [[ ${#missing_deps[@]} -gt 0 ]]; then
         log_err "Fehlende Abhängigkeiten: ${missing_deps[*]}"
         log_err "Installationshinweise:"
-        log_err "  Ubuntu/Debian: sudo apt update && sudo apt install python3 nodejs npm git"
-        log_err "  macOS: brew install python node npm git"
+        log_err "  Ubuntu/Debian: sudo apt update && sudo apt install python3-pip curl git nodejs npm"
+        log_err "  macOS: brew install python pip curl git node npm"
         log_err "  Windows: Verwende WSL oder installiere manuell"
         echo "${missing_deps[@]}"
         return 1
@@ -113,6 +115,11 @@ check_python_environment() {
     else
         log_err "Python 3 nicht gefunden"
         missing+=("python3")
+    fi
+
+    if ! command -v pip >/dev/null; then
+        log_err "pip nicht gefunden"
+        missing+=("pip")
     fi
     
     # Poetry prüfen

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -35,12 +35,12 @@ EOT
 components=()
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --docker) components+=(ensure_docker); shift;;
-        --node) components+=(ensure_node); shift;;
-        --python) components+=(ensure_python); shift;;
+        --docker) components+=(ensure_curl ensure_git ensure_docker); shift;;
+        --node) components+=(ensure_curl ensure_node); shift;;
+        --python) components+=(ensure_python ensure_pip); shift;;
         --poetry) components+=(ensure_poetry); shift;;
         --ci)
-            components=(ensure_python ensure_poetry ensure_node ensure_docker)
+            components=(ensure_python ensure_pip ensure_poetry ensure_node ensure_curl ensure_git ensure_docker)
             AUTO_MODE=true
             shift;;
         --exit-on-fail)
@@ -52,13 +52,13 @@ while [[ $# -gt 0 ]]; do
             PRESET="$1"
             case "$PRESET" in
                 dev)
-                    components=(ensure_docker ensure_node ensure_python ensure_poetry)
+                    components=(ensure_curl ensure_git ensure_docker ensure_node ensure_python ensure_pip ensure_poetry)
                     ;;
                 ci)
-                    components=(ensure_python ensure_poetry)
+                    components=(ensure_python ensure_pip ensure_poetry)
                     ;;
                 minimal)
-                    components=(ensure_python)
+                    components=(ensure_python ensure_pip)
                     ;;
                 *)
                     log_err "Unbekannte Option: $PRESET"; exit 1;;

--- a/scripts/lib/menu_utils.sh
+++ b/scripts/lib/menu_utils.sh
@@ -8,14 +8,14 @@ __menu_utils_init
 
 interactive_menu() {
     local options=(
-        "Komplettes Setup" \
-        "Nur Python-Abhängigkeiten" \
-        "Nur System-Abhängigkeiten" \
-        "Frontend bauen" \
-        "Docker starten" \
-        "MCP starten" \
-        "Status anzeigen" \
-        "Abbrechen"
+        "💡 Schnellstart" \
+        "🧱 Systemabhängigkeiten" \
+        "🐍 Python & Poetry" \
+        "🎨 Frontend bauen" \
+        "🐳 Docker-Komponenten" \
+        "🧪 Tests & CI" \
+        "🔁 Reparatur" \
+        "❌ Abbrechen"
     )
     local count=${#options[@]}
     if command -v whiptail >/dev/null; then
@@ -31,12 +31,12 @@ interactive_menu() {
             8 "${options[7]}" 3>&1 1>&2 2>&3) || exit 1
         case $choice in
             1) RUN_MODE="full" ;;
-            2) RUN_MODE="python" ;;
-            3) RUN_MODE="system" ;;
+            2) RUN_MODE="system" ;;
+            3) RUN_MODE="python" ;;
             4) RUN_MODE="frontend" ;;
             5) RUN_MODE="docker" ;;
-            6) RUN_MODE="mcp" ;;
-            7) RUN_MODE="status" ;;
+            6) RUN_MODE="test" ;;
+            7) RUN_MODE="repair" ;;
             8) exit 0 ;;
         esac
     else
@@ -44,12 +44,12 @@ interactive_menu() {
         select opt in "${options[@]}"; do
             case $REPLY in
                 1) RUN_MODE="full"; break ;;
-                2) RUN_MODE="python"; break ;;
-                3) RUN_MODE="system"; break ;;
+                2) RUN_MODE="system"; break ;;
+                3) RUN_MODE="python"; break ;;
                 4) RUN_MODE="frontend"; break ;;
                 5) RUN_MODE="docker"; break ;;
-                6) RUN_MODE="mcp"; break ;;
-                7) RUN_MODE="status"; break ;;
+                6) RUN_MODE="test"; break ;;
+                7) RUN_MODE="repair"; break ;;
                 8) exit 0 ;;
                 *) echo "Ungültige Auswahl";;
             esac

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -432,6 +432,9 @@ main() {
         status)
             "$SCRIPT_DIR/status.sh" || exit 0
             ;;
+        repair)
+            "$SCRIPT_DIR/repair_env.sh" || exit 1
+            ;;
         test)
             run_project_tests || exit 1
             ;;

--- a/tests/test_setup_matrix.sh
+++ b/tests/test_setup_matrix.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -eu
+
+# Run setup with different presets in check mode
+scripts/setup.sh --check-only --full >/dev/null || true
+scripts/setup.sh --check-only --minimal >/dev/null || true
+scripts/setup.sh --check-only --preset dev >/dev/null || true
+scripts/setup.sh --check-only --preset ci >/dev/null || true
+scripts/setup.sh --check-only --preset minimal >/dev/null || true
+
+# Simulate missing tools by clearing PATH
+PATH="" scripts/setup.sh --check-only >/dev/null || true
+
+echo "setup matrix executed"


### PR DESCRIPTION
## Summary
- extend install utilities with pip, git and curl checks
- update system dependency checks to cover new tools
- rework interactive menu and help overview
- expand install and setup scripts for presets and repair mode
- document new flags and menu options in README
- add test to exercise setup flags

## Testing
- `./tests/ci_check.sh` *(fails: pytest coverage args unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_687617ab518c8324be0340a9b522e4ea