### PR TITLE
Improve interactive sudo handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Das Setup-System erkennt automatisch:
 ## 🛠 Installation über das interaktive Menü
 
 Agent-NN bietet ein interaktives Setup-Menü, mit dem du das System vollständig oder modular einrichten kannst – inklusive Abhängigkeitsprüfung, automatischer Paketinstallation und optionaler `sudo`-Verwendung.
+Das Setup erkennt fehlende Rechte und Pakete automatisch und fragt nach Bestätigung zur Installation.
 
 ### 🔃 Schnellstart (empfohlen)
 

--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -6,6 +6,8 @@ source "$SCRIPT_DIR/lib/log_utils.sh"
 cat <<'EOT'
 Agent-NN Befehlsübersicht
 
+Das Setup erkennt fehlende Rechte und Pakete automatisch und fragt nach Bestätigung zur Installation.
+
   ./scripts/setup.sh         Interaktives Setup-Menü
   ./scripts/install.sh       Einzelne Komponenten installieren
   ./scripts/start_docker.sh  Docker-Services starten

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,6 +14,8 @@ touch "$LOG_ERROR_FILE"
 EXIT_ON_FAIL=false
 PRESET=""
 
+[[ -n "$SUDO_CMD" ]] && require_sudo_if_needed || true
+
 usage() {
     cat <<EOT
 Usage: $(basename "$0") [OPTIONS]

--- a/scripts/lib/menu_utils.sh
+++ b/scripts/lib/menu_utils.sh
@@ -37,7 +37,7 @@ interactive_menu() {
             5) RUN_MODE="docker" ;;
             6) RUN_MODE="test" ;;
             7) RUN_MODE="repair" ;;
-            8) exit 0 ;;
+            8) RUN_MODE="exit" ;;
         esac
     else
         PS3="Auswahl: "
@@ -50,7 +50,7 @@ interactive_menu() {
                 5) RUN_MODE="docker"; break ;;
                 6) RUN_MODE="test"; break ;;
                 7) RUN_MODE="repair"; break ;;
-                8) exit 0 ;;
+                8) RUN_MODE="exit"; break ;;
                 *) echo "Ungültige Auswahl";;
             esac
         done

--- a/tests/test_setup_matrix.sh
+++ b/tests/test_setup_matrix.sh
@@ -2,13 +2,23 @@
 set -eu
 
 # Run setup with different presets in check mode
-scripts/setup.sh --check-only --full >/dev/null || true
-scripts/setup.sh --check-only --minimal >/dev/null || true
-scripts/setup.sh --check-only --preset dev >/dev/null || true
-scripts/setup.sh --check-only --preset ci >/dev/null || true
-scripts/setup.sh --check-only --preset minimal >/dev/null || true
+scripts/setup.sh --check --full >/dev/null || true
+scripts/setup.sh --check --minimal >/dev/null || true
+scripts/setup.sh --check --preset dev >/dev/null || true
+scripts/setup.sh --check --preset ci >/dev/null || true
+scripts/setup.sh --check --preset minimal >/dev/null || true
 
 # Simulate missing tools by clearing PATH
-PATH="" scripts/setup.sh --check-only >/dev/null || true
+PATH="" scripts/setup.sh --check >/dev/null || true
+
+# Check for interactive prompts
+output=$(PATH="" scripts/setup.sh --check 2>&1 || true)
+echo "$output" | grep -q "sudo aktivieren" && echo "sudo prompt" || true
+echo "$output" | grep -q "installiert werden" && echo "install prompt" || true
+
+# Check for interactive prompts
+output=$(PATH="" scripts/setup.sh --check-only 2>&1 || true)
+echo "$output" | grep -q "sudo aktivieren" && echo "sudo prompt" || true
+echo "$output" | grep -q "installiert werden" && echo "install prompt" || true
 
 echo "setup matrix executed"


### PR DESCRIPTION
## Summary
- make setup menu persistent and add interactive retry logic
- auto-detect missing rights via `require_sudo_if_needed`
- ask for packages with `prompt_and_install_if_missing`
- update helper text and README
- extend setup matrix test to check prompts

## Testing
- `ruff check scripts/lib/install_utils.sh scripts/setup.sh scripts/install.sh scripts/lib/menu_utils.sh scripts/help.sh tests/test_setup_matrix.sh`
- `bash tests/test_setup_matrix.sh` *(fails: poetry install error)*

------
https://chatgpt.com/codex/tasks/task_e_68761bb526e0832499b2beaed0d22760