### PR TITLE
Fix Poetry initialization

### DIFF
--- a/scripts/lib/install_utils.sh
+++ b/scripts/lib/install_utils.sh
@@ -9,6 +9,24 @@ __install_utils_init() {
 
 __install_utils_init
 
+: "${POETRY_METHOD:=}"
+if [ -z "$POETRY_METHOD" ]; then
+    log_warn "Variable POETRY_METHOD war nicht gesetzt – fallback auf venv"
+    POETRY_METHOD="venv"
+fi
+
+validate_poetry_method() {
+    case "$1" in
+        system|venv|pipx) return 0 ;;
+        *) echo "Ung\xC3\xBCltige POETRY_METHOD: $1"; return 1 ;;
+    esac
+}
+
+validate_poetry_method "$POETRY_METHOD" || {
+    log_warn "Ung\xC3\xBCltige Methode '$POETRY_METHOD' – fallback auf venv"
+    POETRY_METHOD="venv"
+}
+
 AUTO_MODE="${AUTO_MODE:-false}"
 SUDO_CMD="${SUDO_CMD:-}"
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -350,6 +350,15 @@ main() {
     load_config || true
     load_project_config || true
     ensure_config_file_exists
+
+    # Ensure POETRY_METHOD is initialized
+    POETRY_METHOD=$(load_config_value "POETRY_METHOD" "venv")
+    if [ -z "$POETRY_METHOD" ]; then
+        echo "\U1F527 Kein gespeicherter Wert für POETRY_METHOD – verwende Default: venv"
+        POETRY_METHOD="venv"
+        save_config_value "POETRY_METHOD" "$POETRY_METHOD"
+    fi
+    export POETRY_METHOD
     
     # Argumente parsen
     parse_setup_args "${original_args[@]}"

--- a/tests/test_setup_matrix.sh
+++ b/tests/test_setup_matrix.sh
@@ -1,6 +1,23 @@
 #!/usr/bin/env bash
 set -eu
 
+# Config file missing
+rm -f "$HOME/.agentnn_config"
+scripts/setup.sh --check >/dev/null || true
+
+# Empty config
+: > "$HOME/.agentnn_config"
+scripts/setup.sh --check >/dev/null || true
+
+# Invalid value
+echo 'POETRY_METHOD="invalid"' > "$HOME/.agentnn_config"
+scripts/setup.sh --check >/dev/null || true
+
+# Unset environment variable
+unset POETRY_METHOD
+scripts/setup.sh --check >/dev/null || true
+
+# Valid default value
 echo 'POETRY_METHOD="venv"' > "$HOME/.agentnn_config"
 
 # Run setup with different presets in check mode


### PR DESCRIPTION
## Summary
- keep POETRY_METHOD in setup.sh with default fallback
- validate POETRY_METHOD in install utils
- expand setup matrix test for missing/invalid config

## Testing
- `ruff check .`
- `mypy mcp`
- `pytest -q`
- `bash tests/scripts/test_scripts.sh >/tmp/scripts_test.log`

------
https://chatgpt.com/codex/tasks/task_e_68762ce8d8dc8324b38cf1d46355d85f