### PR TITLE
Fix poetry install failure with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ bash ./scripts/setup.sh --full
 # For other options
 # bash ./scripts/setup.sh --help
 
+# Sollte der Poetry-Schritt scheitern, hilft oft ein erneuter Aufruf mit
+#
+# ```bash
+# poetry install --no-root
+# ```
+
 # System testen
 bash test_system.sh
 

--- a/scripts/lib/install_utils.sh
+++ b/scripts/lib/install_utils.sh
@@ -494,6 +494,11 @@ install_python_dependencies() {
         log_ok "Python-Abhängigkeiten erfolgreich installiert"
         return 0
     else
+        log_warn "poetry install fehlgeschlagen – versuche fallback mit '--no-root'"
+        if poetry install --no-root; then
+            log_ok "Python-Abhängigkeiten mit --no-root installiert"
+            return 0
+        fi
         log_err "Fehler beim Installieren der Python-Abhängigkeiten"
         return 1
     fi


### PR DESCRIPTION
## Summary
- add `poetry install --no-root` fallback to setup utils
- document fallback command in README

## Testing
- `bash tests/ci_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_688b5b3d48848324b9c6239b4075b65c